### PR TITLE
dependencies: security fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,9 +97,9 @@
       "dev": true
     },
     "async": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-      "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "balanced-match": {
@@ -325,15 +325,15 @@
       }
     },
     "ecstatic": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-1.4.1.tgz",
-      "integrity": "sha1-Mst7b6LikNWGaGdNEV6PDD1WfWo=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
       "dev": true,
       "requires": {
-        "he": "^0.5.0",
-        "mime": "^1.2.11",
+        "he": "^1.1.1",
+        "mime": "^1.6.0",
         "minimist": "^1.1.0",
-        "url-join": "^1.0.0"
+        "url-join": "^2.0.5"
       },
       "dependencies": {
         "minimist": {
@@ -676,9 +676,9 @@
       "dev": true
     },
     "he": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
-      "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "hosted-git-info": {
@@ -713,18 +713,18 @@
       }
     },
     "http-server": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.9.0.tgz",
-      "integrity": "sha1-jxsGvcczYY1NxCgxx7oa/04GABo=",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
+      "integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
       "dev": true,
       "requires": {
         "colors": "1.0.3",
         "corser": "~2.0.0",
-        "ecstatic": "^1.4.0",
+        "ecstatic": "^3.0.0",
         "http-proxy": "^1.8.1",
         "opener": "~1.4.0",
         "optimist": "0.6.x",
-        "portfinder": "0.4.x",
+        "portfinder": "^1.0.13",
         "union": "~0.4.3"
       }
     },
@@ -1204,13 +1204,31 @@
       "dev": true
     },
     "portfinder": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-0.4.0.tgz",
-      "integrity": "sha1-o/+t/6/k+5jgYBqF7aJ8J86Eyh4=",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+      "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
       "dev": true,
       "requires": {
-        "async": "0.9.0",
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
         "mkdirp": "0.5.x"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "prelude-ls": {
@@ -1614,9 +1632,9 @@
       }
     },
     "url-join": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"concurrently": "^4.1.0",
-		"http-server": "^0.9.0",
+		"http-server": "^0.11.1",
 		"rollup": "^1.4.0",
 		"eslint": "^5.16.0",
 		"eslint-config-mdcs": "^4.2.3",


### PR DESCRIPTION
#22 Security Alerts
Reverting `http-server` downgrade.

It was meant to fix this behavior: https://github.com/indexzero/http-server/issues/525
But it's not worth introducing a security issue, even though we just use this for local testing. 